### PR TITLE
Add Jest tests for problem generation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+package-lock.json

--- a/package.json
+++ b/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "calcfrenzy",
+  "version": "1.0.0",
+  "scripts": {
+    "test": "jest"
+  },
+  "devDependencies": {
+    "jest": "^29.7.0",
+    "jest-environment-jsdom": "^30.0.0-beta.3"
+  },
+  "jest": {
+    "testEnvironment": "jsdom"
+  }
+}

--- a/script.js
+++ b/script.js
@@ -78,6 +78,15 @@ function endGame() {
     isPlaying = false;
 }
 
+function evaluateExpression(expression) {
+    try {
+        const sanitizedExpression = expression.replace(/[^-()\d/*+.]/g, '');
+        return new Function(`return ${sanitizedExpression}`)();
+    } catch (error) {
+        return NaN;
+    }
+}
+
 function generateProblem() {
     const operators = ['+', '-', '*'];
 
@@ -117,14 +126,6 @@ function generateProblem() {
         return `(${innerExpression1}) ${operator} (${innerExpression2})`;
     }
 
-    function evaluateExpression(expression) {
-        try {
-            const sanitizedExpression = expression.replace(/[^-()\d/*+.]/g, '');
-            return new Function(`return ${sanitizedExpression}`)();
-        } catch (error) {
-            return NaN;
-        }
-    }
 
     let expression;
     let result;
@@ -686,3 +687,7 @@ document.addEventListener('keydown', (event) => {
         levelElement.textContent = level;
     }
 });
+
+if (typeof module !== 'undefined' && module.exports) {
+    module.exports = { generateProblem, evaluateExpression };
+}

--- a/tests/problem.test.js
+++ b/tests/problem.test.js
@@ -1,0 +1,24 @@
+const { generateProblem, evaluateExpression } = require('../script.js');
+
+describe('generateProblem', () => {
+  test('returns non-negative results within expected bounds', () => {
+    global.level = 5;
+    const { expression, result } = generateProblem();
+    expect(typeof expression).toBe('string');
+    expect(typeof result).toBe('number');
+    expect(result).toBeGreaterThanOrEqual(0);
+    const max = 10 + level * 0.5;
+    expect(result).toBeLessThanOrEqual(max);
+  });
+});
+
+describe('evaluateExpression', () => {
+  test('returns correct evaluation for valid expressions', () => {
+    expect(evaluateExpression('2+3')).toBe(5);
+  });
+
+  test('handles malformed expressions safely', () => {
+    expect(evaluateExpression('2++2')).toBeNaN();
+    expect(evaluateExpression('abc')).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary
- create Jest config in package.json and ignore node artifacts
- expose `generateProblem` and `evaluateExpression` for Node
- test arithmetic problem generation and expression evaluation

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684159cc1d3c8331b59da6aa8c4625fe