### PR TITLE
Fix CSS rule nesting

### DIFF
--- a/index.html
+++ b/index.html
@@ -283,6 +283,7 @@
 
         #menu, #endgame {
             text-align: center;
+        }
 
         #answer {
             font-size: 2rem;


### PR DESCRIPTION
## Summary
- close the `#menu, #endgame` block properly so `#answer` is top level

## Testing
- `tidy -e index.html` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684159c6802c83319eeab279921dbb03