### PR TITLE
Fix emoji overlay placement and show bonus

### DIFF
--- a/index.html
+++ b/index.html
@@ -177,6 +177,7 @@
         }
 
         .problem-container {
+            position: relative;
             height: 150px;
             display: flex;
             flex-direction: column;
@@ -198,6 +199,13 @@
           font-size: 3em; /* Regola la dimensione dell'emoji */
           cursor: pointer; /* Cambia il cursore del mouse in una manina */
           transition: opacity 0.2s ease-out; /* Aggiunge una transizione fluida all'opacità */
+        }
+        .time-bonus {
+          position: absolute;
+          color: green;
+          font-size: 1.2em;
+          pointer-events: none;
+          animation: riseAndFade 0.8s forwards;
         }
         .feed-the-animal-overlay {
           position: fixed;
@@ -279,6 +287,11 @@
         @keyframes flip {
             0%, 100% { transform: rotateY(0); }
             50% { transform: rotateY(180deg); }
+        }
+
+        @keyframes riseAndFade {
+            from { opacity: 1; transform: translateY(0); }
+            to { opacity: 0; transform: translateY(-20px); }
         }
 
         #menu, #endgame {

--- a/script.js
+++ b/script.js
@@ -625,17 +625,25 @@ function randomlyReplaceWithEmoji() {
 
   const containerRect = problemContainer.getBoundingClientRect();
   const emojiSize = 50;
-  const maxX = containerRect.width - 100 - emojiSize;
-  const maxY = containerRect.height - 100 - emojiSize;
+  const maxX = containerRect.width - emojiSize;
+  const maxY = containerRect.height - emojiSize;
 
-  randomEmojiElement.style.left = containerRect.left + Math.random() * maxX + 'px';
-  randomEmojiElement.style.top = containerRect.top + Math.random() * maxY + 'px';
+  randomEmojiElement.style.left = Math.random() * maxX + 'px';
+  randomEmojiElement.style.top = Math.random() * maxY + 'px';
   randomEmojiElement.style.fontSize = (2.5 + 2 * Math.random()) + 'em';
   randomEmojiElement.style.transform = `rotate(${Math.random() * 90 - 45}deg)`;
 
   problemContainer.appendChild(randomEmojiElement);
 
   randomEmojiElement.addEventListener('click', () => {
+    const bonus = document.createElement('div');
+    bonus.textContent = '+1s';
+    bonus.classList.add('time-bonus');
+    bonus.style.left = '0';
+    bonus.style.top = '-10px';
+    randomEmojiElement.appendChild(bonus);
+    setTimeout(() => bonus.remove(), 800);
+
     randomEmojiElement.style.transition = 'opacity 0.1s ease-out';
     randomEmojiElement.style.opacity = '0';
     setTimeout(() => {


### PR DESCRIPTION
## Summary
- anchor emoji overlays relative to game area
- add floating time bonus when clicking emoji

## Testing
- `npm install --silent`
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68415e85c8d483319dd84e35e06aa716