### PR TITLE
Handle debug mode with shift

### DIFF
--- a/script.js
+++ b/script.js
@@ -673,15 +673,33 @@ function clearAnswer() {
 
 // *** Eventi di Debugging ***
 document.addEventListener('keydown', (event) => {
-    if (event.key >= '1' && event.key <= '9') {
+    if (isPlaying) {
+        if (event.key >= '0' && event.key <= '9' && !event.shiftKey) {
+            // Permette di usare i numeri della tastiera come pulsanti della calcolatrice
+            typeNumber(parseInt(event.key));
+            return; // Evita che i tasti numerici attivino le funzioni di debug durante il gioco
+        } else if (event.key === 'Enter') {
+            // Invio equivale al tasto OK della calcolatrice
+            submitAnswer();
+            return;
+        } else if (event.key === 'Backspace' || event.key.toLowerCase() === 'c') {
+            // Backspace o 'C' cancellano la risposta
+            clearAnswer();
+            return;
+        }
+    }
+
+    const debugModifierPressed = isPlaying ? event.shiftKey : true;
+
+    if (event.key >= '1' && event.key <= '9' && debugModifierPressed) {
         const disturbanceIndex = parseInt(event.key) - 1;
         const disturbanceName = Object.keys(disturbanceFrequencies)[disturbanceIndex];
         if (disturbanceName) {
             applyDisturbance(disturbanceName, 1); // Forza il disturbo
         }
-    } else if (event.key === '0') {
+    } else if (event.key === '0' && debugModifierPressed) {
         resetTimer();
-    } else if (event.key === '-') {
+    } else if (event.key === '-' && debugModifierPressed) {
         level += 10;
         levelElement.textContent = level;
     }


### PR DESCRIPTION
## Summary
- let players use 0-9 from the keyboard while the game runs
- require holding Shift to trigger debug shortcuts so numbers don't clash

## Testing
- `npm install`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68415d540bbc8331a6c0a10f466e6496